### PR TITLE
fix: restore separate replication target collection task

### DIFF
--- a/roles/dirsrv_common/tasks/preflight.yml
+++ b/roles/dirsrv_common/tasks/preflight.yml
@@ -116,6 +116,7 @@
   tags: [preflight]
 
 # DNS/TCP gating for replication targets (runs when replication topology data present)
+- name: Preflight | Collect replication targets
   ansible.builtin.set_fact:
     __dirsrv_unique_targets: "{{ (
         dirsrv_repl_agreements | default({})


### PR DESCRIPTION
## Summary
- ensure `dirsrv_ldapi_socket_path_effective` is set regardless of replication presence by giving target collection its own task

## Testing
- `ansible-playbook --syntax-check site.yml`
- `ansible-lint` *(fails: Unknown error when calling Galaxy: 403 Forbidden)*
- `yamllint .`


------
https://chatgpt.com/codex/tasks/task_e_68c031a44d2c8321a8eb71e8c1e42f61