### PR TITLE
fix: safe init group lookup in replication agreements

### DIFF
--- a/roles/dirsrv_repl/tasks/agreements.yml
+++ b/roles/dirsrv_repl/tasks/agreements.yml
@@ -316,7 +316,7 @@
   ansible.builtin.set_fact:
     _dirsrv_init_groups: >-
       {{ (_dirsrv_init_groups | default({}))
-         | combine( { item.0.key: ((_dirsrv_init_groups[item.0.key] | default([])) + [ item.1 ]) }, recursive=True) }}
+         | combine({ item.0.key: (((_dirsrv_init_groups | default({})).get(item.0.key, [])) + [ item.1 ]) }, recursive=True) }}
   with_subelements:
     - "{{ dirsrv_repl_agreements | dict2items }}"
     - value


### PR DESCRIPTION
## Summary
- avoid undefined-variable failures when building per-suffix init groups

## Testing
- `ansible-playbook --syntax-check site.yml`
- `ansible-lint` *(fails: load-failure[runtimeerror])* 
- `yamllint .`


------
https://chatgpt.com/codex/tasks/task_e_68c098acbd74832184bc834cfb4a493e